### PR TITLE
実行キューの一覧を取得する際、クエリにworkflow_idを指定する場合 organization_id か project_id が必要である旨を追記

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -546,6 +546,27 @@ curl --location --request GET "https://api.roboticcrowd.com/v1/session_queues?pa
 
 取得するページです。
 
+#### organization_id
+
+**初期値**
+
+無し
+
+**説明**
+
+query に workflow_id を指定するとき、組織 ID（organization_id）か プロジェクト ID（project_id）を指定する必要があります。
+
+#### project_id
+
+**初期値**
+
+無し
+
+**説明**
+
+query に workflow_id を指定するとき、組織 ID（organization_id）か プロジェクト ID（project_id）を指定する必要があります。
+
+
 ### 応答
 
 JSON オブジェクトを返却します。


### PR DESCRIPTION
# JiraのURL
https://tutorial-inc.atlassian.net/browse/RPA-3500

# やったこと
-ドキュメント修正
  - organization_id, project_id の追記

# やっていないこと
- api としてパラメータを要求するのが正しいかの検討

# 重点的に見てほしいところ
- マージ先が正しいこと